### PR TITLE
Add Support for Plaintext and PDF Attachments

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ torchvision
 torchaudio
 transformers>=4.31.0
 # llama-cpp-python is also installed, but because of special arguments it is installed within install.sh instead.
+pypdf
 pytest==7.4.0
 pytest-dependency==0.5.1
 openai

--- a/synthea/ContextManager.py
+++ b/synthea/ContextManager.py
@@ -4,7 +4,6 @@ Generate a prompt for the AI to respond to, given the
 message history and persona.
 """
 from typing import AsyncIterator, Optional
-import asyncio
 import discord
 import pypdf
 from jinja2 import Environment
@@ -181,7 +180,7 @@ class ContextManager:
                 if not system_prompt and args.use_as_system_prompt:
                     system_prompt = args.prompt
                     continue
-            text, added_tokens = self._get_text(message, config)
+            text, added_tokens = await self._get_text(message, config)
 
             # # 
             if not args and message.author.id == self.bot_user_id:
@@ -229,7 +228,7 @@ class ContextManager:
         print(attachment_string)
         return attachment_string
 
-    def _get_text(self, message: discord.Message, config: Config):
+    async def _get_text(self, message: discord.Message, config: Config):
         """
         Gets the text from a message and counts the tokens.
 
@@ -251,8 +250,7 @@ class ContextManager:
 
         # Iterate through any attachments associated with the message
         for attachment in message.attachments:
-            loop = asyncio.get_event_loop()
-            attachment_content = loop.run_until_complete(self.read_attachment(attachment))
+            attachment_content = await self.read_attachment(attachment)
             text = text + "\n\n" + attachment_content
 
         tokens = len(text) // self.EST_CHARS_PER_TOKEN

--- a/synthea/ContextManager.py
+++ b/synthea/ContextManager.py
@@ -222,14 +222,17 @@ class ContextManager:
         if "text/plain" in message.content_type:
             attachment_string = attachment_bytes.decode()
         elif "application/pdf" in message.content_type:
-            print("Getting the PDF as a File object")
-            message_file = await message.to_file()
-            reader = pypdf.PdfReader(message_file)
+            print("Saving the pdf attachment")
+            await message.save(message.filename)
+            reader = pypdf.PdfReader(message.filename)
 
             print(f"Found {len(reader.pages)} pages in PDF. Reading them.")
             for page in reader.pages:
                 page_text = page.extract_text()
                 attachment_string = attachment_string + "\n" + page_text
+            
+            print("Removing the saved file")
+            os.remove(message.filename)
 
         print("Obtained the following text from the attachment as a string")
         print(attachment_string)

--- a/synthea/ContextManager.py
+++ b/synthea/ContextManager.py
@@ -222,17 +222,14 @@ class ContextManager:
         if "text/plain" in message.content_type:
             attachment_string = attachment_bytes.decode()
         elif "application/pdf" in message.content_type:
-            print("Saving the pdf attachment")
-            await message.save(message.filename)
-            reader = pypdf.PdfReader(message.filename)
+            print("Getting the PDF as a File object")
+            message_file = await message.to_file()
+            reader = pypdf.PdfReader(message_file)
 
             print(f"Found {len(reader.pages)} pages in PDF. Reading them.")
             for page in reader.pages:
                 page_text = page.extract_text()
                 attachment_string = attachment_string + "\n" + page_text
-            
-            print("Removing the saved file")
-            os.remove(message.filename)
 
         print("Obtained the following text from the attachment as a string")
         print(attachment_string)

--- a/synthea/ContextManager.py
+++ b/synthea/ContextManager.py
@@ -217,12 +217,11 @@ class ContextManager:
     
     async def read_attachment(self, message: discord.Attachment):
         attachment_string = ""
-        if "text" in message.content_type:
-            attachment_bytes = await message.read()
-            if "txt" in message.content_type:
-                attachment_string = attachment_bytes.decode()
-            elif "pdf" in message.content_type:
-                attachment_string = pypdf.PdfReader(attachment_bytes)
+        attachment_bytes = await message.read()
+        if "text/plain" in message.content_type:
+            attachment_string = attachment_bytes.decode()
+        elif "application/pdf" in message.content_type:
+            attachment_string = pypdf.PdfReader(attachment_bytes)
 
         print("Obtained the following text from the attachment as a string")
         print(attachment_string)

--- a/synthea/ContextManager.py
+++ b/synthea/ContextManager.py
@@ -5,6 +5,7 @@ message history and persona.
 """
 from typing import AsyncIterator, Optional
 import discord
+import pypdf
 from jinja2 import Environment
 import yaml
 

--- a/synthea/ContextManager.py
+++ b/synthea/ContextManager.py
@@ -7,6 +7,7 @@ from typing import AsyncIterator, Optional
 import discord
 import pypdf
 from jinja2 import Environment
+import os
 import yaml
 
 from synthea.CommandParser import ChatbotParser, CommandError, ParsedArgs, ParserExitedException
@@ -221,7 +222,17 @@ class ContextManager:
         if "text/plain" in message.content_type:
             attachment_string = attachment_bytes.decode()
         elif "application/pdf" in message.content_type:
-            attachment_string = pypdf.PdfReader(attachment_bytes)
+            print("Saving the pdf attachment")
+            await message.save(message.filename)
+            reader = pypdf.PdfReader(message.filename)
+
+            print(f"Found {len(reader.pages)} pages in PDF. Reading them.")
+            for page in reader.pages:
+                page_text = page.extract_text()
+                attachment_string = attachment_string + "\n" + page_text
+            
+            print("Removing the saved file")
+            os.remove(message.filename)
 
         print("Obtained the following text from the attachment as a string")
         print(attachment_string)


### PR DESCRIPTION
Creates a new function for reading attachment data. Currently supports `application/pdf` and `text/plain` `content_type`s.