### PR TITLE
feat: use case-insensitive matching when triggering the bot to respond

### DIFF
--- a/synthea/SyntheaClient.py
+++ b/synthea/SyntheaClient.py
@@ -140,7 +140,7 @@ class SyntheaClient(discord.Client):
 
         # by default, don't respond to messages unless it was directed at the bot
         message_invokes_chatbot: bool = False
-        if message.content.startswith(COMMAND_START_STR):
+        if message.content.lower().startswith(COMMAND_START_STR.lower()):
             # if the message starts with the start string, then it was definitely directed at the bot.
             message_invokes_chatbot = True
         elif message.reference:


### PR DESCRIPTION
Case-sensitive matching has caused some confusion by users. This PR makes the trigger phrase case-insensitive.